### PR TITLE
Fix ResolvePackageNotFound error for M1 Mac

### DIFF
--- a/environment-m1.yaml
+++ b/environment-m1.yaml
@@ -3,8 +3,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - python=3.8.5
-  - pip=20.3
+  - pip
   - pytorch=1.12.1
   - torchvision=0.13.1
   - numpy=1.19.2
@@ -13,3 +12,4 @@ dependencies:
       - transformers==4.19.2
       - Pillow
       - Flask
+      - python=3.8.5


### PR DESCRIPTION
I was getting this error when running

`% conda env create -f environment-m1.yaml`